### PR TITLE
fix out of memory bug

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -48,6 +48,9 @@ const (
 
 	flagTelemetryEnabled = "telemetry-enabled"
 	flagTelemetryPort    = "telemetry-port"
+
+	flagWorkerPoolSize         = "worker-pool-size"
+	flagWorkerBlockingTaskSize = "worker-blocking-task-size"
 )
 
 // InitCmd returns the command that should be run in order to properly initialize BDJuno

--- a/cmd/init/types.go
+++ b/cmd/init/types.go
@@ -60,6 +60,9 @@ func DefaultConfigCreator(cmd *cobra.Command) types.Config {
 	telemetryEnabled, _ := cmd.Flags().GetBool(flagTelemetryEnabled)
 	telemetryPort, _ := cmd.Flags().GetUint(flagTelemetryPort)
 
+	workerPoolSize, _ := cmd.Flags().GetInt(flagWorkerPoolSize)
+	workerBlockingTaskSize, _ := cmd.Flags().GetInt(flagWorkerBlockingTaskSize)
+
 	return types.NewConfig(
 		types.NewRPCConfig(rpcClientName, rpcAddr),
 		types.NewGrpcConfig(grpcAddr, grpcInsecure),
@@ -93,6 +96,10 @@ func DefaultConfigCreator(cmd *cobra.Command) types.Config {
 		types.NewTelemetryConfig(
 			telemetryEnabled,
 			telemetryPort,
+		),
+		types.NewWorkerConfig(
+			workerPoolSize,
+			workerBlockingTaskSize,
 		),
 	)
 }

--- a/cmd/init/types.go
+++ b/cmd/init/types.go
@@ -61,7 +61,6 @@ func DefaultConfigCreator(cmd *cobra.Command) types.Config {
 	telemetryPort, _ := cmd.Flags().GetUint(flagTelemetryPort)
 
 	workerPoolSize, _ := cmd.Flags().GetInt(flagWorkerPoolSize)
-	workerBlockingTaskSize, _ := cmd.Flags().GetInt(flagWorkerBlockingTaskSize)
 
 	return types.NewConfig(
 		types.NewRPCConfig(rpcClientName, rpcAddr),
@@ -99,7 +98,6 @@ func DefaultConfigCreator(cmd *cobra.Command) types.Config {
 		),
 		types.NewWorkerConfig(
 			workerPoolSize,
-			workerBlockingTaskSize,
 		),
 	)
 }

--- a/cmd/parse/parse.go
+++ b/cmd/parse/parse.go
@@ -103,7 +103,7 @@ func StartParsing(ctx *Context) error {
 
 	workerCfg := types.Cfg.GetWorkerConfig()
 	// Create workers
-	pool, err := ants.NewPool(workerCfg.GetPoolSize(), ants.WithMaxBlockingTasks(workerCfg.GetBlockingTaskSize()))
+	pool, err := ants.NewPool(workerCfg.GetPoolSize())
 	if err != nil {
 		return err
 	}

--- a/db/database.go
+++ b/db/database.go
@@ -17,6 +17,10 @@ type Database interface {
 	// An error is returned if the operation fails.
 	SaveBlock(block types.Block) error
 
+	// SaveTx will be called to save each transaction contained inside a block.
+	// An error is returned if the operation fails.
+	SaveTx(tx types.Tx) error
+
 	// SaveMessage stores a single message.
 	// An error is returned if the operation fails.
 	SaveMessage(msg types.Message) error

--- a/db/postgresql/solana.go
+++ b/db/postgresql/solana.go
@@ -77,75 +77,37 @@ func (db *Database) HasBlock(height uint64) (bool, error) {
 
 // SaveBlock implements db.Database
 func (db *Database) SaveBlock(block types.Block) error {
-	dbTx, err := db.Sqlx.Beginx()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = dbTx.Rollback()
-	}()
-	if err := saveBlock(dbTx, block); err != nil {
-		return err
-	}
-
-	if err := saveTxs(dbTx, block.Txs); err != nil {
-		return err
-	}
-	err = dbTx.Commit()
-	return err
-}
-
-// saveBlocks store a block inside the database
-func saveBlock(dbTx *sqlx.Tx, block types.Block) error {
 	stmt := `
 INSERT INTO block (slot, hash, proposer, timestamp)
 VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING`
 	proposer := sql.NullString{Valid: len(block.Proposer) != 0, String: block.Proposer}
-	_, err := dbTx.Exec(
+	_, err := db.Sqlx.Exec(
 		stmt, block.Slot, block.Hash, proposer, block.Timestamp,
 	)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
-// saveTxs stores all the given transactions inside the database
-func saveTxs(dbTx *sqlx.Tx, txs []types.Tx) error {
-	if len(txs) == 0 {
-		return nil
-	}
-	stmt := `INSERT INTO transaction (hash, slot, error, fee, logs) VALUES`
-	var params []interface{}
-	paramsNumber := 5
-	for i, tx := range txs {
-		bi := i * paramsNumber
-		stmt += fmt.Sprintf("($%d, $%d, $%d, $%d, $%d),", bi+1, bi+2, bi+3, bi+4, bi+5)
-		params = append(
-			params,
-			tx.Hash,
-			tx.Slot,
-			tx.Successful(),
-			tx.Fee,
-			pq.Array(tx.Logs),
-		)
-	}
-	stmt = stmt[:len(stmt)-1]
-	stmt += `
-ON CONFLICT (hash) DO NOTHING
-	`
-	_, err := dbTx.Exec(stmt, params...)
-	if err != nil {
-		return err
-	}
-	return nil
+// SaveTx implements db.Database
+func (db *Database) SaveTx(tx types.Tx) error {
+	stmt := `
+INSERT INTO transaction (hash, slot, error, fee, logs)
+VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`
+	_, err := db.Sqlx.Exec(
+		stmt,
+		tx.Hash,
+		tx.Slot,
+		tx.Successful(),
+		tx.Fee,
+		pq.Array(tx.Logs),
+	)
+	return err
 }
 
 // SaveMessage implements db.Database
 func (db *Database) SaveMessage(msg types.Message) error {
 	stmt := `
 INSERT INTO message(transaction_hash, index, program, involved_accounts, type, value) 
-VALUES ($1, $2, $3, $4, $5, $6)`
+VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING`
 	if msg.InvolvedAccounts == nil {
 		msg.InvolvedAccounts = []string{}
 	}

--- a/db/schema/07-bpf-loader.sql
+++ b/db/schema/07-bpf-loader.sql
@@ -25,5 +25,3 @@ CREATE TABLE program_data_account
     state                   TEXT    NOT NULL
 );
 CREATE INDEX program_data_account_authority_index ON program_data_account (update_authority);
-
-

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/lib/pq v1.9.0
 	github.com/mr-tron/base58 v1.2.0
+	github.com/panjf2000/ants/v2 v2.4.6
 	github.com/pelletier/go-toml v1.8.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -486,6 +486,8 @@ github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
+github.com/panjf2000/ants/v2 v2.4.6 h1:drmj9mcygn2gawZ155dRbo+NfXEfAssjZNU1qoIb4gQ=
+github.com/panjf2000/ants/v2 v2.4.6/go.mod h1:f6F0NZVFsGCp5A7QW/Zj/m92atWwOkY0OIhFxRNFr4A=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1052,6 +1054,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/modules/vote/handle_msg.go
+++ b/modules/vote/handle_msg.go
@@ -16,8 +16,6 @@ func HandleMsg(msg types.Message, tx types.Tx, db db.VoteDb, client client.Proxy
 		return handleMsgInitialize(msg, tx, db)
 	case "authorize":
 		return handleMsgAuthorize(msg, tx, db, client)
-	case "withdraw":
-		return handleMsgWithdraw(msg, tx, db, client)
 	case "updateValidatorIdentity":
 		return handleMsgUpdateValidatorIdentity(msg, tx, db, client)
 	case "updateCommission":

--- a/modules/vote/utils.go
+++ b/modules/vote/utils.go
@@ -35,6 +35,6 @@ func updateVoteAccount(address string, currentSlot uint64, db db.VoteDb, client 
 		voteAccount.Node.String(),
 		voteAccount.Withdrawer.String(),
 		voteAccount.Voter[0].Pubkey.String(),
-		0,
+		voteAccount.Commission,
 	)
 }

--- a/modules/vote/utils.go
+++ b/modules/vote/utils.go
@@ -13,7 +13,6 @@ func updateVoteAccount(address string, currentSlot uint64, db db.VoteDb, client 
 	if !db.CheckVoteAccountLatest(address, currentSlot) {
 		return nil
 	}
-
 	info, err := client.AccountInfo(address)
 	if err != nil {
 		return err

--- a/solana/account/vote.go
+++ b/solana/account/vote.go
@@ -8,7 +8,7 @@ import (
 func voteParse(decoder bincode.Decoder, bz []byte) interface{} {
 	if len(bz) != 0 {
 		var voteAccount VoteAccount
-		decoder.Decode(bz, &voteAccount)
+		decoder.Decode(bz[4:], &voteAccount)
 		return voteAccount
 	}
 	return nil

--- a/types/config.go
+++ b/types/config.go
@@ -22,6 +22,7 @@ type configToml struct {
 	Parsing   *parsingConfig   `toml:"parsing"`
 	Pruning   *pruningConfig   `toml:"pruning"`
 	Telemetry *telemetryConfig `toml:"telemetry"`
+	Worker    *workerConfig    `toml:"worker"`
 }
 
 // DefaultConfigParser attempts to read and parse a Juno config from the given string bytes.
@@ -38,6 +39,7 @@ func DefaultConfigParser(configData []byte) (Config, error) {
 		cfg.Parsing,
 		cfg.Pruning,
 		cfg.Telemetry,
+		cfg.Worker,
 	), err
 }
 
@@ -53,6 +55,7 @@ type Config interface {
 	GetParsingConfig() ParsingConfig
 	GetPruningConfig() PruningConfig
 	GetTelemetryConfig() TelemetryConfig
+	GetWorkerConfig() WorkerConfig
 }
 
 var _ Config = &config{}
@@ -67,6 +70,7 @@ type config struct {
 	Parsing   ParsingConfig   `toml:"parsing"`
 	Pruning   PruningConfig   `toml:"pruning"`
 	Telemetry TelemetryConfig `toml:"telemetry"`
+	Worker    WorkerConfig    `toml:"worker"`
 }
 
 // NewConfig builds a new Config instance
@@ -75,6 +79,7 @@ func NewConfig(
 	chainConfig ChainConfig, dbConfig DatabaseConfig,
 	loggingConfig LoggingConfig, parsingConfig ParsingConfig,
 	pruningConfig PruningConfig, telemetryConfig TelemetryConfig,
+	workerConfig WorkerConfig,
 ) Config {
 	return &config{
 		RPC:       rpcConfig,
@@ -85,6 +90,7 @@ func NewConfig(
 		Parsing:   parsingConfig,
 		Pruning:   pruningConfig,
 		Telemetry: telemetryConfig,
+		Worker:    workerConfig,
 	}
 }
 
@@ -150,6 +156,14 @@ func (c *config) GetTelemetryConfig() TelemetryConfig {
 		return DefaultTelemetryConfig()
 	}
 	return c.Telemetry
+}
+
+// GetWorkerConfig implements Config
+func (c *config) GetWorkerConfig() WorkerConfig {
+	if c.Worker == nil {
+		return DefaultWorkerConfig()
+	}
+	return c.Worker
 }
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -548,7 +562,7 @@ func (p *pruningConfig) GetInterval() int64 {
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-// TelemetryConfig contains the configuration of the pruning strategy
+// TelemetryConfig contains the configuration of the telemetry strategy
 type TelemetryConfig interface {
 	IsEnabled() bool
 	GetPort() uint
@@ -582,4 +596,42 @@ func (p *telemetryConfig) IsEnabled() bool {
 // GetPort implements TelemetryConfig
 func (p *telemetryConfig) GetPort() uint {
 	return p.Port
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+// WorkerConfig contains the configuration of the worker strategy
+type WorkerConfig interface {
+	GetPoolSize() int
+	GetBlockingTaskSize() int
+}
+
+var _ WorkerConfig = &workerConfig{}
+
+type workerConfig struct {
+	PoolSize         int `toml:"poll_size"`
+	BlockingTaskSize int `toml:"blocking_task_size"`
+}
+
+// NewWorkerConfig allows to build a new WorkerConfig instance
+func NewWorkerConfig(poolSize, blockingTaskSize int) WorkerConfig {
+	return &workerConfig{
+		PoolSize:         poolSize,
+		BlockingTaskSize: blockingTaskSize,
+	}
+}
+
+// DefaultWorkerConfig returns the default WorkerConfig instance
+func DefaultWorkerConfig() WorkerConfig {
+	return NewWorkerConfig(25, 25)
+}
+
+// GetPoolSize implements WorkerConfig
+func (w *workerConfig) GetPoolSize() int {
+	return w.PoolSize
+}
+
+// GetBlockingTaskSize implements WorkerConfig
+func (w *workerConfig) GetBlockingTaskSize() int {
+	return w.BlockingTaskSize
 }

--- a/types/config.go
+++ b/types/config.go
@@ -623,7 +623,7 @@ func NewWorkerConfig(poolSize, blockingTaskSize int) WorkerConfig {
 
 // DefaultWorkerConfig returns the default WorkerConfig instance
 func DefaultWorkerConfig() WorkerConfig {
-	return NewWorkerConfig(25, 25)
+	return NewWorkerConfig(500, 500)
 }
 
 // GetPoolSize implements WorkerConfig

--- a/types/config.go
+++ b/types/config.go
@@ -603,35 +603,27 @@ func (p *telemetryConfig) GetPort() uint {
 // WorkerConfig contains the configuration of the worker strategy
 type WorkerConfig interface {
 	GetPoolSize() int
-	GetBlockingTaskSize() int
 }
 
 var _ WorkerConfig = &workerConfig{}
 
 type workerConfig struct {
-	PoolSize         int `toml:"poll_size"`
-	BlockingTaskSize int `toml:"blocking_task_size"`
+	PoolSize int `toml:"poll_size"`
 }
 
 // NewWorkerConfig allows to build a new WorkerConfig instance
-func NewWorkerConfig(poolSize, blockingTaskSize int) WorkerConfig {
+func NewWorkerConfig(poolSize int) WorkerConfig {
 	return &workerConfig{
-		PoolSize:         poolSize,
-		BlockingTaskSize: blockingTaskSize,
+		PoolSize: poolSize,
 	}
 }
 
 // DefaultWorkerConfig returns the default WorkerConfig instance
 func DefaultWorkerConfig() WorkerConfig {
-	return NewWorkerConfig(500, 500)
+	return NewWorkerConfig(500)
 }
 
 // GetPoolSize implements WorkerConfig
 func (w *workerConfig) GetPoolSize() int {
 	return w.PoolSize
-}
-
-// GetBlockingTaskSize implements WorkerConfig
-func (w *workerConfig) GetBlockingTaskSize() int {
-	return w.BlockingTaskSize
 }

--- a/types/config.go
+++ b/types/config.go
@@ -620,7 +620,7 @@ func NewWorkerConfig(poolSize int) WorkerConfig {
 
 // DefaultWorkerConfig returns the default WorkerConfig instance
 func DefaultWorkerConfig() WorkerConfig {
-	return NewWorkerConfig(500)
+	return NewWorkerConfig(1_000_000)
 }
 
 // GetPoolSize implements WorkerConfig

--- a/worker/types.go
+++ b/worker/types.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"github.com/panjf2000/ants/v2"
+
 	"github.com/forbole/soljuno/solana/parser"
 	"github.com/forbole/soljuno/types/logging"
 
@@ -17,6 +19,7 @@ type Context struct {
 	Parser      parser.Parser
 	Logger      logging.Logger
 
+	Pool    *ants.Pool
 	Queue   types.SlotQueue
 	Modules []modules.Module
 }
@@ -27,6 +30,7 @@ func NewContext(
 	db db.Database,
 	parser parser.Parser,
 	logger logging.Logger,
+	pool *ants.Pool,
 	queue types.SlotQueue,
 	modules []modules.Module,
 ) *Context {
@@ -36,6 +40,7 @@ func NewContext(
 		Parser:      parser,
 		Logger:      logger,
 
+		Pool:    pool,
 		Queue:   queue,
 		Modules: modules,
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -104,12 +104,11 @@ func (w Worker) ExportBlock(block types.Block) error {
 		return fmt.Errorf("failed to persist block: %s", err)
 	}
 
-	// Handle modules
+	// Handle block events
 	return w.pool.Submit(func() { w.handleBlock(block) })
 }
 
-// ExportTxs accepts a slice of transactions and persists then inside the database.
-// An error is returned if the write fails.
+// handleBlock handles all the events in a block
 func (w Worker) handleBlock(block types.Block) {
 	// Handle all the transactions inside the block
 	w.handleBlockModules(block)
@@ -131,7 +130,7 @@ func (w Worker) handleBlockModules(block types.Block) {
 	}
 }
 
-// handleTx handles all the the element contained inside the transaction
+// handleTx handles all the events in a transaction
 func (w Worker) handleTx(tx types.Tx) {
 	err := w.db.SaveTx(tx)
 	if err != nil {
@@ -149,7 +148,7 @@ func (w Worker) handleTx(tx types.Tx) {
 	w.handleMessageModules(tx)
 }
 
-// handleMessageModules handles all the messages contained inside the transaction with modules
+// handleMessageModules handles all the messages events in a transaction
 func (w Worker) handleMessageModules(tx types.Tx) {
 	for _, msg := range tx.Messages {
 		for _, module := range w.modules {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->
Closes #43 
This PR attempts to fix the bug of memory crash since current version doesn't limit the number of goroutine. In addition, goroutines are created per msg so the program copies a tons of msg data to the task queue, this is the reason why the error happens.

To solve the bug, the way this PR uses is to limit the number of goroutine by the goroutine pool, then reduce the asynchronous task by indexing msgs per block instead of per msg. 

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
