### PR TITLE
Paul/fix pruning

### DIFF
--- a/db/postgresql/pruning.go
+++ b/db/postgresql/pruning.go
@@ -9,8 +9,7 @@ var _ db.PruningDb = &Database{}
 func (db *Database) Prune(slot uint64) error {
 	_, err := db.Sqlx.Exec(`
 DELETE FROM message 
-USING transaction 
-WHERE message.transaction_hash = transaction.hash AND transaction.slot <= $1
+WHERE slot <= $1
 `, slot)
 	return err
 }

--- a/db/postgresql/solana.go
+++ b/db/postgresql/solana.go
@@ -106,14 +106,15 @@ VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`
 // SaveMessage implements db.Database
 func (db *Database) SaveMessage(msg types.Message) error {
 	stmt := `
-INSERT INTO message(transaction_hash, index, inner_index, program, involved_accounts, raw_data, type, value) 
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT DO NOTHING`
+INSERT INTO message(transaction_hash, slot, index, inner_index, program, involved_accounts, raw_data, type, value) 
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT DO NOTHING`
 	if msg.InvolvedAccounts == nil {
 		msg.InvolvedAccounts = []string{}
 	}
 	_, err := db.Sqlx.Exec(
 		stmt,
 		msg.TxHash,
+		msg.Slot,
 		msg.Index,
 		msg.InnerIndex,
 		msg.Program,

--- a/db/schema/00-solana.sql
+++ b/db/schema/00-solana.sql
@@ -21,6 +21,7 @@ CREATE INDEX transaction_slot_index ON transaction (slot);
 CREATE TABLE message
 (
     transaction_hash    TEXT    NOT NULL REFERENCES transaction (hash),
+    slot                BIGINT  NOT NULL REFERENCES block (slot),
     index               INT     NOT NULL,
     inner_index         INT     NOT NULL,
     program             TEXT    NOT NULL,      
@@ -30,6 +31,8 @@ CREATE TABLE message
     value               JSONB   NOT NULL DEFAULT '{}'::JSONB
 );
 CREATE INDEX message_transaction_hash_index ON message (transaction_hash);
+CREATE INDEX message_slot_index ON message (slot);
+
 
 /**
  * This function is used to find all the utils that involve any of the given addresses and have
@@ -43,9 +46,8 @@ CREATE FUNCTION messages_by_address(
     RETURNS SETOF message AS
 $$
 SELECT 
-    message.transaction_hash, message.index, message.inner_index, message.program, message.involved_accounts, message.raw_data, message.type, message.value
+    message.transaction_hash, message.slot, message.index, message.inner_index, message.program, message.involved_accounts, message.raw_data, message.type, message.value
 FROM message
-         JOIN transaction t on message.transaction_hash = t.hash
 WHERE (cardinality(types) = 0 OR type = ANY (types))
   AND addresses && involved_accounts
 ORDER BY slot DESC

--- a/types/solana.go
+++ b/types/solana.go
@@ -76,7 +76,7 @@ func NewBlockFromResult(parser parser.Parser, slot uint64, b clienttypes.BlockRe
 			accounts = getAccounts(accountKeys, msg.Accounts)
 			programID := accountKeys[msg.ProgramIDIndex]
 			parsed := parser.Parse(accounts, programID, msg.Data)
-			msgs = append(msgs, NewMessage(hash, i, innerIndex, accountKeys[msg.ProgramIDIndex], accounts, msg.Data, parsed))
+			msgs = append(msgs, NewMessage(hash, slot, i, innerIndex, accountKeys[msg.ProgramIDIndex], accounts, msg.Data, parsed))
 			innerIndex++
 
 			if inner, ok := innerInstructionMap[uint8(i)]; ok {
@@ -84,7 +84,7 @@ func NewBlockFromResult(parser parser.Parser, slot uint64, b clienttypes.BlockRe
 					accounts = getAccounts(accountKeys, innerMsg.Accounts)
 					programID := accountKeys[innerMsg.ProgramIDIndex]
 					parsed := parser.Parse(accounts, programID, innerMsg.Data)
-					msgs = append(msgs, NewMessage(hash, i, innerIndex, accountKeys[innerMsg.ProgramIDIndex], accounts, innerMsg.Data, parsed))
+					msgs = append(msgs, NewMessage(hash, slot, i, innerIndex, accountKeys[innerMsg.ProgramIDIndex], accounts, innerMsg.Data, parsed))
 					innerIndex++
 				}
 			}
@@ -177,6 +177,7 @@ func (tx Tx) Successful() bool {
 
 type Message struct {
 	TxHash           string
+	Slot             uint64
 	Index            int
 	InnerIndex       int
 	Program          string
@@ -187,6 +188,7 @@ type Message struct {
 
 func NewMessage(
 	hash string,
+	slot uint64,
 	index int,
 	innerIndex int,
 	program string,
@@ -196,6 +198,7 @@ func NewMessage(
 ) Message {
 	return Message{
 		TxHash:           hash,
+		Slot:             slot,
 		Index:            index,
 		InnerIndex:       innerIndex,
 		Program:          program,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->

This PR is the fixing mentioned on #71. It adds the slot field for message then it can be pruned by the slot field without joining transaction table. 

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
