### PR TITLE
Fix parsed vote withdraw instruction

### DIFF
--- a/solana/program/vote/parsed_type.go
+++ b/solana/program/vote/parsed_type.go
@@ -74,10 +74,9 @@ func NewParsedVote(
 //____________________________________________________________________________
 
 type ParsedWithdraw struct {
-	VoteAccount       string `json:"voteAccount"`
-	Destination       string `json:"destination"`
-	WithdrawAuthority string `json:"withdrawAuthority"`
-	Lamports          uint64 `json:"lamports"`
+	VoteAccount string `json:"voteAccount"`
+	Destination string `json:"destination"`
+	Lamports    uint64 `json:"lamports"`
 }
 
 func NewParsedWithdraw(
@@ -85,10 +84,9 @@ func NewParsedWithdraw(
 	instruction WithdrawInstruction,
 ) ParsedWithdraw {
 	return ParsedWithdraw{
-		VoteAccount:       accounts[0],
-		Destination:       accounts[1],
-		WithdrawAuthority: accounts[2],
-		Lamports:          instruction.Amount,
+		VoteAccount: accounts[0],
+		Destination: accounts[1],
+		Lamports:    instruction.Amount,
 	}
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
<!-- Small description -->
The rpc response of vote withdraw message returns 2 accounts instead of 3 accounts as docs shows. So it changed the parsed withdraw instructions to fix the issue.

## Checklist
- [ ] Targeted PR against correct branch.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
